### PR TITLE
Added set_selection

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -270,14 +270,14 @@ end
 export set_selection
 """
     set_selection(variable::Variable,
-                       start::Union{Nothing,NTuple{N,Int} where N,CartesianIndex},
-                       count::Union{Nothing,NTuple{N,Int} where N,CartesianIndex})
+                    start::Union{NTuple{N,Int} where N, CartesianIndex},
+                    count::Union{NTuple{N,Int} where N, CartesianIndex} )
 
     Set the selection for reading or alter the selection for writing if define_variable was called with constant_dims = false.
 """
 function set_selection(variable::Variable,
-                       start::NTuple{N,Int} where {N,CartesianIndex},
-                       count::NTuple{N,Int} where {N,CartesianIndex} )
+                       start::Union{NTuple{N,Int} where N, CartesianIndex}
+                       count::Union{NTuple{N,Int} where N, CartesianIndex} )
 
     @assert length(start) == length(count)
     ndims = length(start)
@@ -289,4 +289,3 @@ function set_selection(variable::Variable,
     Error(err) ≠ error_none && return nothing
     return ()
 end
-

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -276,7 +276,7 @@ export set_selection
     Set the selection for reading or alter the selection for writing if define_variable was called with constant_dims = false.
 """
 function set_selection(variable::Variable,
-                       start::Union{NTuple{N,Int} where N, CartesianIndex}
+                       start::Union{NTuple{N,Int} where N, CartesianIndex},
                        count::Union{NTuple{N,Int} where N, CartesianIndex} )
 
     @assert length(start) == length(count)

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -78,7 +78,7 @@ end
 # """
 #     type_string = variable_type_string(variable::Variable)
 #     type_string::Union{Nothing,String}
-# 
+#
 # Retrieve variable type in string form "char", "unsigned long", etc.
 # This reports C type names.
 # """
@@ -266,3 +266,27 @@ function Base.maximum(variable::Variable)
     Error(err) ≠ error_none && return nothing
     return varmax[]
 end
+
+export set_selection
+"""
+    set_selection(variable::Variable,
+                       start::Union{Nothing,NTuple{N,Int} where N,CartesianIndex},
+                       count::Union{Nothing,NTuple{N,Int} where N,CartesianIndex})
+
+    Set the selection for reading or alter the selection for writing if define_variable was called with constant_dims = false.
+"""
+function set_selection(variable::Variable,
+                       start::NTuple{N,Int} where {N,CartesianIndex},
+                       count::NTuple{N,Int} where {N,CartesianIndex} )
+
+    @assert length(start) == length(count)
+    ndims = length(start)
+
+    err = ccall((:adios2_set_selection, libadios2_c), Cint,
+            (Ptr{Cvoid}, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}),
+            variable.ptr, ndims, Csize_t[reverse(Tuple(start))...], Csize_t[reverse(Tuple(count))...])
+
+    Error(err) ≠ error_none && return nothing
+    return ()
+end
+


### PR DESCRIPTION
Can you please check the "where" clauses in the function signature? I'm not sure if I got them right. I tested this on write and it worked (e.g. I could write a block, call set_selection, and write another block from the same MPI rank). I still need to check if this works for reading, but I think it will. 