### PR TITLE
Fix compatibility lower bounds and add comprehensive testing

### DIFF
--- a/.github/workflows/CompatLowerBounds.yml
+++ b/.github/workflows/CompatLowerBounds.yml
@@ -1,0 +1,76 @@
+name: CompatLowerBounds
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  test:
+    name: Julia ${{matrix.version}} - ${{matrix.os}} - ${{matrix.arch}} - ${{github.event_name}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        include:
+          - arch: "aarch64"
+            os: "macOS-latest"
+            version: "1.11"
+            skipmpi: 'true'     # Why does this not work in CI? This works locally.
+          - arch: "x64"
+            os: "macOS-latest"
+            version: "1.11"
+            skipmpi: 'true'     # Why does this not work in CI? This works locally.
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "1.11"
+          # Windows gets stuck after `File write tests`. Don't know why.
+          # - arch: "x64"
+          #   os: "windows-latest"
+          #   version: "1.11"
+          #   skipmpi: 'true'     # MPI doesn't work on Windows
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "1.10"
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "1.9"
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "1.8"
+            skipmpi: 'true'     # Why does this not work?
+          - arch: "x64"
+            os: "ubuntu-latest"
+            version: "1.7"
+          # - arch: "x64"
+          #   os: "ubuntu-latest"
+          #   version: "1.6"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+      - uses: julia-actions/cache@v2
+
+      - name: Downgrade to lower bound versions
+        uses: julia-actions/julia-downgrade-compat@v1
+        with:
+          skip: Pkg, TOML
+
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - name: Install mpiexecjl
+        if: ${{matrix.skipmpi != 'true'}}
+        run: |
+          julia --project=@. --eval '
+            using MPI
+            MPI.install_mpiexecjl()' &&
+          echo '~/.julia/bin/mpiexecjl -n 2 --project=@. "$@"' >~/.julia/bin/mpiexecjl2 &&
+          chmod a+x ~/.julia/bin/mpiexecjl2
+      - uses: julia-actions/julia-runtest@v1
+        if: ${{matrix.skipmpi != 'true'}}
+        with:
+          prefix: $HOME/.julia/bin/mpiexecjl2
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: eschnett/ADIOS2.jl

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [compat]
-ADIOS2_jll = "2.7.1"
+ADIOS2_jll = "2.10"
 MPI = "0.17, 0.18, 0.19, 0.20"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,4 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 [compat]
 ADIOS2_jll = "2.10"
 MPI = "0.17, 0.18, 0.19, 0.20"
-julia = "1.6"
+julia = "1.7"

--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,5 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [compat]
 ADIOS2_jll = "2.10"
-MPI = "0.17, 0.18, 0.19, 0.20"
+MPI = "0.20"
 julia = "1.7"


### PR DESCRIPTION
### Issue
I've experienced compatibility issues when installing `ADIOS2.jl` in my other projects.
Since the [compat] in `Project.toml` is outdated, it allows an older version of `ADIOS2_jll` and other dependencies to be installed, leading to build failures.

### Changes

**1. Updated Project.toml compatibility bounds**
After testing on macOS (arm64), updated minimum required versions to ensure proper functionality:
- `ADIOS2_jll`: `2.7.1` → `2.10`
- `MPI`: `0.17, 0.18, 0.19, 0.20` → `0.20` 
- `julia`: `1.6` → `1.7`

**2. Added CompatLowerBounds workflow**
Created a new dedicated workflow (`CompatLowerBounds.yml`) to properly test compatibility lower bounds, which the existing CI doesn't validate:

- **Triggers**: Automatic daily cron schedule + manual dispatch when needed
- **Matrix**: Same OS/architecture combinations as main CI
- **Key addition**: Uses `julia-actions/julia-downgrade-compat@v1` to downgrade dependencies to their minimum compatible versions before testing

This ensures that the specified lower bounds actually work in practice, preventing future compatibility issues for downstream users.