### PR TITLE
Get string length from file if possible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Erik Schnetter <schnetter@gmail.com>"]
 name = "ADIOS2"
 uuid = "e0ce9d3b-0dbd-416f-8264-ccca772f60ec"
-version = "1.5.0"
+version = "1.5.1"
 
 [compat]
 ADIOS2_jll = "201.1100.2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ uuid = "e0ce9d3b-0dbd-416f-8264-ccca772f60ec"
 version = "1.5.0"
 
 [compat]
-ADIOS2_jll = "2.10.4"
+ADIOS2_jll = "201.1100.2"
 MPI = "0.20"
 julia = "1.10"
 

--- a/src/ADIOS2.jl
+++ b/src/ADIOS2.jl
@@ -10,6 +10,7 @@ else
     error("ADIOS2 is not properly installed. Please run Pkg.build(\"ADIOS2\") ",
           "and restart Julia.")
 end
+libadios2_c_handle::Ptr{Nothing} = Ptr{Nothing}()
 
 ### Helpers
 
@@ -34,6 +35,7 @@ include("extended_highlevel/adios_load.jl")
 
 function __init__()
     check_deps()
+    global libadios2_c_handle = dlopen(libadios2_c)
     return
 end
 

--- a/src/ADIOS2.jl
+++ b/src/ADIOS2.jl
@@ -10,7 +10,7 @@ else
     error("ADIOS2 is not properly installed. Please run Pkg.build(\"ADIOS2\") ",
           "and restart Julia.")
 end
-libadios2_c_handle::Ptr{Nothing} = Ptr{Nothing}()
+const have_adios2_get_string = (dlsym(dlopen(libadios2_c), :adios2_get_string; throw_error=false) !== nothing)
 
 ### Helpers
 
@@ -35,7 +35,6 @@ include("extended_highlevel/adios_load.jl")
 
 function __init__()
     check_deps()
-    global libadios2_c_handle = dlopen(libadios2_c)
     return
 end
 

--- a/src/attribute.jl
+++ b/src/attribute.jl
@@ -111,17 +111,17 @@ function data(attribute::Attribute)
     tp ≡ nothing && return nothing
     if tp ≡ String
         if isval
-            if dlsym(libadios2_c_handle, :adios2_attribute_string_data; throw_error=false) === nothing
-                # `adios2_attribute_string_data()` function is not available, fall back to
-                # hard-coded maximum size
-                buffer = fill(Cchar(0), string_array_element_max_size)
-            else
+            if have_adios2_get_string
                 string_length = Ref{Cint}()
                 length_err = ccall((:adios2_attribute_string_data, libadios2_c), Cint,
                                    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                                    attribute.ptr, C_NULL, string_length)
                 Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(attribute))")
                 buffer = fill(Cchar(0), string_length[] + 1)
+            else
+                # `adios2_attribute_string_data()` function is not available, fall back to
+                # hard-coded maximum size
+                buffer = fill(Cchar(0), string_array_element_max_size)
             end
             out_sz = Ref{Csize_t}()
             err = ccall((:adios2_attribute_data, libadios2_c), Cint,
@@ -132,12 +132,7 @@ function data(attribute::Attribute)
             data = unsafe_string(pointer(buffer))
             return data
         else
-            if dlsym(libadios2_c_handle, :adios2_attribute_string_data_array; throw_error=false) === nothing
-                # `adios2_attribute_string_data()` function is not available, fall back to
-                # hard-coded maximum size
-                arrays = [Array{Cchar}(undef, string_array_element_max_size)
-                          for i in 1:sz]
-            else
+            if have_adios2_get_string
                 string_lengths = fill(Cint(0), sz)
                 string_lengths_ptr = pointer(string_lengths)
                 length_err = ccall((:adios2_attribute_string_data_array, libadios2_c), Cint,
@@ -145,6 +140,11 @@ function data(attribute::Attribute)
                                    attribute.ptr, C_NULL, string_lengths_ptr)
                 Error(length_err) ≠ error_none && error("Failed to get length of strings for $(name(attribute))")
                 arrays = [Array{Cchar}(undef, l + 1) for l in string_lengths]
+            else
+                # `adios2_attribute_string_data()` function is not available, fall back to
+                # hard-coded maximum size
+                arrays = [Array{Cchar}(undef, string_array_element_max_size)
+                          for i in 1:sz]
             end
             buffers = [pointer(array) for array in arrays]::Vector{Ptr{Cchar}}
             out_sz = Ref{Csize_t}()

--- a/src/attribute.jl
+++ b/src/attribute.jl
@@ -110,7 +110,6 @@ function data(attribute::Attribute)
     tp = type(attribute)
     tp ≡ nothing && return nothing
     if tp ≡ String
-        libadios2_c_handle = dlopen(libadios2_c)
         if isval
             if dlsym(libadios2_c_handle, :adios2_attribute_string_data; throw_error=false) === nothing
                 # `adios2_attribute_string_data()` function is not available, fall back to

--- a/src/attribute.jl
+++ b/src/attribute.jl
@@ -110,8 +110,20 @@ function data(attribute::Attribute)
     tp = type(attribute)
     tp ≡ nothing && return nothing
     if tp ≡ String
+        libadios2_c_handle = dlopen(libadios2_c)
         if isval
-            buffer = fill(Cchar(0), string_array_element_max_size)
+            if dlsym(libadios2_c_handle, :adios2_attribute_string_data; throw_error=false) === nothing
+                # `adios2_attribute_string_data()` function is not available, fall back to
+                # hard-coded maximum size
+                buffer = fill(Cchar(0), string_array_element_max_size)
+            else
+                string_length = Ref{Cint}()
+                length_err = ccall((:adios2_attribute_string_data, libadios2_c), Cint,
+                                   (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
+                                   attribute.ptr, C_NULL, string_length)
+                Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(attribute))")
+                buffer = fill(Cchar(0), string_length[] + 1)
+            end
             out_sz = Ref{Csize_t}()
             err = ccall((:adios2_attribute_data, libadios2_c), Cint,
                         (Ptr{Cchar}, Ref{Csize_t}, Ptr{Cvoid}), buffer, out_sz,
@@ -121,8 +133,20 @@ function data(attribute::Attribute)
             data = unsafe_string(pointer(buffer))
             return data
         else
-            arrays = [Array{Cchar}(undef, string_array_element_max_size)
-                      for i in 1:sz]
+            if dlsym(libadios2_c_handle, :adios2_attribute_string_data_array; throw_error=false) === nothing
+                # `adios2_attribute_string_data()` function is not available, fall back to
+                # hard-coded maximum size
+                arrays = [Array{Cchar}(undef, string_array_element_max_size)
+                          for i in 1:sz]
+            else
+                string_lengths = fill(Cint(0), sz)
+                string_lengths_ptr = pointer(string_lengths)
+                length_err = ccall((:adios2_attribute_string_data_array, libadios2_c), Cint,
+                                   (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
+                                   attribute.ptr, C_NULL, string_lengths_ptr)
+                Error(length_err) ≠ error_none && error("Failed to get length of strings for $(name(attribute))")
+                arrays = [Array{Cchar}(undef, l + 1) for l in string_lengths]
+            end
             buffers = [pointer(array) for array in arrays]::Vector{Ptr{Cchar}}
             out_sz = Ref{Csize_t}()
             err = ccall((:adios2_attribute_data, libadios2_c), Cint,

--- a/src/attribute.jl
+++ b/src/attribute.jl
@@ -117,7 +117,7 @@ function data(attribute::Attribute)
                                    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                                    attribute.ptr, C_NULL, string_length)
                 Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(attribute))")
-                buffer = fill(Cchar(0), string_length[] + 1)
+                buffer = Vector{Cchar}(undef, string_length[])
             else
                 # `adios2_attribute_string_data()` function is not available, fall back to
                 # hard-coded maximum size
@@ -129,17 +129,21 @@ function data(attribute::Attribute)
                         attribute.ptr)
             @assert out_sz[] == sz
             Error(err) ≠ error_none && return nothing
-            data = unsafe_string(pointer(buffer))
+            if have_adios2_get_string
+                data = unsafe_string(pointer(buffer), string_length[])
+            else
+                data = unsafe_string(pointer(buffer))
+            end
             return data
         else
             if have_adios2_get_string
-                string_lengths = fill(Cint(0), sz)
+                string_lengths = Vector{Csize_t}(undef, sz)
                 string_lengths_ptr = pointer(string_lengths)
                 length_err = ccall((:adios2_attribute_string_data_array, libadios2_c), Cint,
                                    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                                    attribute.ptr, C_NULL, string_lengths_ptr)
                 Error(length_err) ≠ error_none && error("Failed to get length of strings for $(name(attribute))")
-                arrays = [Array{Cchar}(undef, l + 1) for l in string_lengths]
+                arrays = [Array{Cchar}(undef, l) for l in string_lengths]
             else
                 # `adios2_attribute_string_data()` function is not available, fall back to
                 # hard-coded maximum size
@@ -153,7 +157,11 @@ function data(attribute::Attribute)
                         out_sz, attribute.ptr)
             @assert out_sz[] == sz
             Error(err) ≠ error_none && return nothing
-            data = unsafe_string.(buffers)::Vector{String}
+            if have_adios2_get_string
+                data = String[unsafe_string(b, l) for (b, l) ∈ zip(buffers, string_lengths)]
+            else
+                data = unsafe_string.(buffers)::Vector{String}
+            end
             # Use `arrays` again to ensure it is not GCed too early
             buffers .= pointer.(arrays)
             return data

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -240,17 +240,17 @@ function Base.get(engine::Engine, variable::Variable,
     if T ≡ String
         eltype(data) <: AbstractString ||
             throw(ArgumentError("ADIOS2: `data` element type for string variables must be a subtype of `AbstractString`"))
-        if dlsym(libadios2_c_handle, :adios2_get_string; throw_error=false) === nothing
-            # `adios2_get_string()` function is not available, fall back to hard-coded
-            # maximum size
-            buffer = fill(Cchar(0), string_array_element_max_size + 1)
-        else
+        if have_adios2_get_string
             string_length = Ref{Cint}()
             length_err = ccall((:adios2_get_string, libadios2_c), Cint,
                                (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                                engine.ptr, variable.ptr, C_NULL, string_length)
             Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(variable))")
             buffer = fill(Cchar(0), string_length[] + 1)
+        else
+            # `adios2_get_string()` function is not available, fall back to hard-coded
+            # maximum size
+            buffer = fill(Cchar(0), string_array_element_max_size + 1)
         end
         err = ccall((:adios2_get, libadios2_c), Cint,
                     (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint), engine.ptr,

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -240,7 +240,6 @@ function Base.get(engine::Engine, variable::Variable,
     if T ≡ String
         eltype(data) <: AbstractString ||
             throw(ArgumentError("ADIOS2: `data` element type for string variables must be a subtype of `AbstractString`"))
-        libadios2_c_handle = dlopen(libadios2_c)
         if dlsym(libadios2_c_handle, :adios2_get_string; throw_error=false) === nothing
             # `adios2_get_string()` function is not available, fall back to hard-coded
             # maximum size

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -246,26 +246,33 @@ function Base.get(engine::Engine, variable::Variable,
                                (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                                engine.ptr, variable.ptr, C_NULL, string_length)
             Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(variable))")
-            buffer = fill(Cchar(0), string_length[] + 1)
+            buffer = Vector{Cchar}(undef, string_length[])
+            err = ccall((:adios2_get, libadios2_c), Cint,
+                        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint), engine.ptr,
+                        variable.ptr, buffer, Cint(launch))
+            string_value = unsafe_string(pointer(buffer), string_length[])
         else
             # `adios2_get_string()` function is not available, fall back to hard-coded
-            # maximum size
+            # maximum size.
+            # No length passed to `unsafe_string()`, so buffer must be a null-terminated
+            # string.
             buffer = fill(Cchar(0), string_array_element_max_size + 1)
+            err = ccall((:adios2_get, libadios2_c), Cint,
+                        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint), engine.ptr,
+                        variable.ptr, buffer, Cint(launch))
+            string_value = unsafe_string(pointer(buffer))
         end
-        err = ccall((:adios2_get, libadios2_c), Cint,
-                    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint), engine.ptr,
-                    variable.ptr, buffer, Cint(launch))
         if launch ≡ mode_deferred
             push!(engine.get_targets, (engine, variable))
             if data isa Ref
                 push!(engine.get_tasks,
-                      () -> data[] = unsafe_string(pointer(buffer)))
+                      () -> data[] = string_value)
             else
                 push!(engine.get_tasks,
-                      () -> data[begin] = unsafe_string(pointer(buffer)))
+                      () -> data[begin] = string_value)
             end
         else
-            data[] = unsafe_string(pointer(buffer))
+            data[] = string_value
         end
     else
         eltype(data) ≡ T ||

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -240,7 +240,19 @@ function Base.get(engine::Engine, variable::Variable,
     if T ≡ String
         eltype(data) <: AbstractString ||
             throw(ArgumentError("ADIOS2: `data` element type for string variables must be a subtype of `AbstractString`"))
-        buffer = fill(Cchar(0), string_array_element_max_size + 1)
+        libadios2_c_handle = dlopen(libadios2_c)
+        if dlsym(libadios2_c_handle, :adios2_get_string; throw_error=false) === nothing
+            # `adios2_get_string()` function is not available, fall back to hard-coded
+            # maximum size
+            buffer = fill(Cchar(0), string_array_element_max_size + 1)
+        else
+            string_length = Ref{Cint}()
+            length_err = ccall((:adios2_get_string, libadios2_c), Cint,
+                               (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
+                               engine.ptr, variable.ptr, C_NULL, string_length)
+            Error(length_err) ≠ error_none && error("Failed to get length of string for $(name(variable))")
+            buffer = fill(Cchar(0), string_length[] + 1)
+        end
         err = ccall((:adios2_get, libadios2_c), Cint,
                     (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint), engine.ptr,
                     variable.ptr, buffer, Cint(launch))

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -203,11 +203,22 @@ Schedule writing a scalar variable to a file.
 
 The variable is not written until `adios_perform_puts!` is called and
 the file is flushed or closed.
+
+# Keywords
+- `global_value`: for scalar variables (`shape=nothing`), `global_value=true` can be
+  passed to indicate that the variable will be a 'global' value, written once per step, as
+  opposed to a 'local' value written once per MPI rank per step.
 """
-function adios_put!(file::AdiosFile, name::AbstractString, scalar::AdiosType)
+function adios_put!(file::AdiosFile, name::AbstractString, scalar::T;
+                    global_value=false) where T <: AdiosType
     var = inquire_variable(file.io, name)
     if isnothing(var)
-        var = define_variable(file.io, name, scalar)
+        if T === String && !global_value
+            error("String variables cannot be defined as local values, because they "
+                  * "cannot be written as arrays. Pass `global_value=true` to define as "
+                  * "a global value instead.")
+        end
+        var = define_variable(file.io, name, scalar; global_value)
     end
     put!(file.engine, var, scalar)
     return var

--- a/src/io.jl
+++ b/src/io.jl
@@ -39,7 +39,7 @@ export define_variable
                          shape::Union{Nothing,NTuple{N,Int} where N,CartesianIndex}=nothing,
                          start::Union{Nothing,NTuple{N,Int} where N,CartesianIndex}=nothing,
                          count::Union{Nothing,NTuple{N,Int} where N,CartesianIndex}=nothing,
-                         constant_dims::Bool=false)
+                         constant_dims::Bool=false; global_value=false)
     variable::Union{Nothing,Variable}
 
 Define a variable within `io`.
@@ -54,6 +54,11 @@ Define a variable within `io`.
 - `count`: local dimension
 - `constant_dims`: `true`: shape, start, count won't change; `false`:
   shape, start, count will change after definition
+
+# Keywords
+- `global_value`: for scalar variables (`shape=nothing`), `global_value=true` can be
+  passed to indicate that the variable will be a 'global' variable, written once per step,
+  as opposed to a 'local' variable written once per MPI rank per step.
 """
 function define_variable(io::AIO, name::AbstractString, type::Type,
                          shape::LocalValue)
@@ -84,8 +89,16 @@ function define_variable(io::AIO, name::AbstractString, type::Type,
     return ptr == C_NULL ? nothing : Variable(ptr, io.adios)
 end
 
-function define_variable(io::AIO, name::AbstractString, var::AdiosType)
-    return define_variable(io, name, typeof(var), LocalValue())
+function define_variable(io::AIO, name::AbstractString, var::AdiosType;
+                         global_value=false)
+    if global_value
+        # Define a 'global' value that will be stored as a scalar.
+        return define_variable(io, name, typeof(var))
+    else
+        # Define a 'local' value that will be stored in an array whose length is the
+        # number of MPI ranks.
+        return define_variable(io, name, typeof(var), LocalValue())
+    end
 end
 function define_variable(io::AIO, name::AbstractString,
                          arr::AbstractArray{<:AdiosType})

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -147,7 +147,9 @@ const ENGINE_TYPE = "BP4"
          # <https://github.com/ornladios/ADIOS2/issues/2734>
          # Complex{Float32}, Complex{Float64},
                   Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64]
-        val = T ≡ String ? "42" : T(42)
+        # Use a ludicrously long string for T≡String to test that we are not relying on
+        # the old hard-coded maximum length.
+        val = T ≡ String ? "42"^2500 : T(42)
         val::T
 
         # Attribute
@@ -171,7 +173,9 @@ const ENGINE_TYPE = "BP4"
 
         # Attribute arrays need to have at least one element (why?)
         for len in 1:2:3
-            vals = (T ≡ String ? String["42", "", "44"] : T[42, 0, 44])[1:len]
+            # Include a ludicrously long string for T≡String to test that we are not
+            # relying on the old hard-coded maximum length.
+            vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
 
             # Attribute array
             nm = "array.p$rankstr.$T.$len"
@@ -211,12 +215,12 @@ const ENGINE_TYPE = "BP4"
         if D == -1
             @test is_value(attr)
             @test size(attr) == 1
-            val = T ≡ String ? "42" : T(42)
+            val = T ≡ String ? "42"^2500 : T(42)
             @test data(attr) == val
         else
             @test !is_value(attr)
             @test size(attr) == len
-            vals = (T ≡ String ? String["42", "", "44"] : T[42, 0, 44])[1:len]
+            vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
             @test data(attr) == vals
         end
     end
@@ -482,7 +486,7 @@ GC.gc(true)
     @test attr0 isa Nothing
 
     for ((D, len, varname, T), (nm, attr)) in attributes
-        val = T ≡ String ? "42" : T(42)
+        val = T ≡ String ? "42"^2500 : T(42)
         val::T
 
         attr1 = inquire_attribute(io, nm)
@@ -498,12 +502,12 @@ GC.gc(true)
                 # Length-1 non-string attribute arrays are mis-interpreted as values
                 @test is_value(attr)
                 @test size(attr) == len
-                vals = (T ≡ String ? String["42", "", "44"] : T[42, 0, 44])[1:len]
+                vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
                 @test [data(attr)] == vals
             else
                 @test !is_value(attr)
                 @test size(attr) == len
-                vals = (T ≡ String ? String["42", "", "44"] : T[42, 0, 44])[1:len]
+                vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
                 @test data(attr) == vals
             end
         end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -19,7 +19,7 @@ const ENGINE_TYPE = "BP4"
 
 # When ADIOS2 does not provide functions that can get the string length, getting
 # "42"^2500 would segfault because it is longer than a hard-coded limit.
-string_value = (adios_has_string_length_funcs ? "42"^2500 : "42")
+string_value = (have_adios2_get_string ? "42"^2500 : "42")
 
 @testset "File write tests" begin
     # Set up ADIOS

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -17,6 +17,10 @@ const filename = "$dirname/test.bp"
 # "BP3", "BP4", "BP5", "HDF5", "SST", "SSC", "DataMan", "Inline", "Null"
 const ENGINE_TYPE = "BP4"
 
+# When ADIOS2 does not provide functions that can get the string length, getting
+# "42"^2500 would segfault because it is longer than a hard-coded limit.
+string_value = (adios_has_string_length_funcs ? "42"^2500 : "42")
+
 @testset "File write tests" begin
     # Set up ADIOS
     if use_mpi
@@ -149,7 +153,7 @@ const ENGINE_TYPE = "BP4"
                   Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64]
         # Use a ludicrously long string for T≡String to test that we are not relying on
         # the old hard-coded maximum length.
-        val = T ≡ String ? "42"^2500 : T(42)
+        val = T ≡ String ? string_value : T(42)
         val::T
 
         # Attribute
@@ -175,7 +179,7 @@ const ENGINE_TYPE = "BP4"
         for len in 1:2:3
             # Include a ludicrously long string for T≡String to test that we are not
             # relying on the old hard-coded maximum length.
-            vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
+            vals = (T ≡ String ? String[string_value, "", "44"] : T[42, 0, 44])[1:len]
 
             # Attribute array
             nm = "array.p$rankstr.$T.$len"
@@ -215,12 +219,12 @@ const ENGINE_TYPE = "BP4"
         if D == -1
             @test is_value(attr)
             @test size(attr) == 1
-            val = T ≡ String ? "42"^2500 : T(42)
+            val = T ≡ String ? string_value : T(42)
             @test data(attr) == val
         else
             @test !is_value(attr)
             @test size(attr) == len
-            vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
+            vals = (T ≡ String ? String[string_value, "", "44"] : T[42, 0, 44])[1:len]
             @test data(attr) == vals
         end
     end
@@ -486,7 +490,7 @@ GC.gc(true)
     @test attr0 isa Nothing
 
     for ((D, len, varname, T), (nm, attr)) in attributes
-        val = T ≡ String ? "42"^2500 : T(42)
+        val = T ≡ String ? string_value : T(42)
         val::T
 
         attr1 = inquire_attribute(io, nm)
@@ -502,12 +506,12 @@ GC.gc(true)
                 # Length-1 non-string attribute arrays are mis-interpreted as values
                 @test is_value(attr)
                 @test size(attr) == len
-                vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
+                vals = (T ≡ String ? String[string_value, "", "44"] : T[42, 0, 44])[1:len]
                 @test [data(attr)] == vals
             else
                 @test !is_value(attr)
                 @test size(attr) == len
-                vals = (T ≡ String ? String["42"^2500, "", "44"] : T[42, 0, 44])[1:len]
+                vals = (T ≡ String ? String[string_value, "", "44"] : T[42, 0, 44])[1:len]
                 @test data(attr) == vals
             end
         end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -50,17 +50,18 @@ const ENGINE_TYPE = "BP4"
         @test match(r"Variable\(.+\)", showmime(gval)) ≢ nothing
         variables[(shapeid_global_value, -1, -1, T)] = (nm, gval)
 
-        # Local value
-        nm = "lvalue.p$rankstr.$T"
-        lval = define_variable(io, nm, val)
-        @test lval isa Variable
-        @test match(r"Variable\(name=.+,type=.+,shapeid=.+,shape=.+\)",
-                    string(lval)) ≢ nothing
-        @test match(r"Variable\(.+\)", showmime(lval)) ≢ nothing
-        variables[(shapeid_local_value, -1, -1, T)] = (nm, lval)
-
         # String arrays are not supported
         if T ≢ String
+            # Local value
+            # These are written as array variables, which is not allowed for String
+            nm = "lvalue.p$rankstr.$T"
+            lval = define_variable(io, nm, val)
+            @test lval isa Variable
+            @test match(r"Variable\(name=.+,type=.+,shapeid=.+,shape=.+\)",
+                        string(lval)) ≢ nothing
+            @test match(r"Variable\(.+\)", showmime(lval)) ≢ nothing
+            variables[(shapeid_local_value, -1, -1, T)] = (nm, lval)
+
             for D in 1:3, len in 0:2
                 # size
                 sz = ntuple(d -> len == 0 ? 0 : len == 1 ? 1 : d, D)
@@ -314,14 +315,15 @@ GC.gc(true)
         @test gval isa Variable
         variables[(shapeid_global_value, -1, -1, T)] = (nm, gval)
 
-        # Local value
-        nm = "lvalue.p$rankstr.$T"
-        lval = inquire_variable(io, nm)
-        @test lval isa Variable
-        variables[(shapeid_local_value, -1, -1, T)] = (nm, lval)
-
         # String arrays are not supported
         if T ≢ String
+            # Local value
+            # These are written as array variables, which is not allowed for String
+            nm = "lvalue.p$rankstr.$T"
+            lval = inquire_variable(io, nm)
+            @test lval isa Variable
+            variables[(shapeid_local_value, -1, -1, T)] = (nm, lval)
+
             for D in 1:3, len in 0:2
                 # Global array
                 nm = "garray.$T.$D.$len"

--- a/test/highlevel.jl
+++ b/test/highlevel.jl
@@ -23,6 +23,7 @@ if comm_rank == 0
         adios_put!(file, "v5", makearray(3, float(ℯ)))
         adios_put!(file, "g1/v6", makearray(4, float(ℯ)))
         adios_put!(file, "g1/g2/v7", makearray(5, float(ℯ)))
+        adios_put!(file, "long_string", "a"^5000; global_value=true)
 
         @test shapeid(inquire_variable(file.io, "v1")) == shapeid_local_value
         @test shapeid(inquire_variable(file.io, "v_global")) == shapeid_global_value
@@ -32,6 +33,7 @@ if comm_rank == 0
         @test shapeid(inquire_variable(file.io, "g1/v6")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "g1/g2/v7")) ==
               shapeid_local_array
+        @test shapeid(inquire_variable(file.io, "long_string")) == shapeid_global_value
 
         adios_define_attribute(file, "v4/a4", float(π))
         adios_define_attribute(file, "v5", "a5", [float(π)])
@@ -78,7 +80,7 @@ if comm_rank == 0
         @test adios_attribute_data(file, "g1/v6", "a6") == [float(π), 0]
 
         @test Set(adios_all_variable_names(file)) ==
-              Set(["v1", "v_global", "v3", "v4", "v5", "g1/v6", "g1/g2/v7"])
+              Set(["v1", "v_global", "v3", "v4", "v5", "g1/v6", "g1/g2/v7", "long_string"])
         @test Set(adios_group_variable_names(file, "g1")) == Set(["g1/v6"])
         @test Set(adios_group_variable_names(file, "g1/g2")) ==
               Set(["g1/g2/v7"])
@@ -92,6 +94,7 @@ if comm_rank == 0
         @test shapeid(inquire_variable(file.io, "g1/v6")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "g1/g2/v7")) ==
               shapeid_local_array
+        @test shapeid(inquire_variable(file.io, "long_string")) == shapeid_global_value
 
         @test ndims(inquire_variable(file.io, "v1")) == 1
         @test ndims(inquire_variable(file.io, "v_global")) == 0
@@ -100,6 +103,7 @@ if comm_rank == 0
         @test ndims(inquire_variable(file.io, "v5")) == 3
         @test ndims(inquire_variable(file.io, "g1/v6")) == 4
         @test ndims(inquire_variable(file.io, "g1/g2/v7")) == 5
+        @test ndims(inquire_variable(file.io, "long_string")) == 0
 
         @test shape(inquire_variable(file.io, "v1")) == (1,)
         @test shape(inquire_variable(file.io, "v_global")) == ()
@@ -108,6 +112,7 @@ if comm_rank == 0
         @test shape(inquire_variable(file.io, "v5")) ≡ nothing
         @test shape(inquire_variable(file.io, "g1/v6")) ≡ nothing
         @test shape(inquire_variable(file.io, "g1/g2/v7")) ≡ nothing
+        @test shape(inquire_variable(file.io, "long_string")) == ()
 
         @test start(inquire_variable(file.io, "v1")) == (0,)
         @test start(inquire_variable(file.io, "v_global")) == ()
@@ -116,6 +121,7 @@ if comm_rank == 0
         @test start(inquire_variable(file.io, "v5")) ≡ nothing
         @test start(inquire_variable(file.io, "g1/v6")) ≡ nothing
         @test start(inquire_variable(file.io, "g1/g2/v7")) ≡ nothing
+        @test start(inquire_variable(file.io, "long_string")) == ()
 
         @test count(inquire_variable(file.io, "v1")) == (1,)
         @test count(inquire_variable(file.io, "v_global")) == ()
@@ -124,6 +130,7 @@ if comm_rank == 0
         @test count(inquire_variable(file.io, "v5")) == (1, 1, 1)
         @test count(inquire_variable(file.io, "g1/v6")) == (1, 1, 1, 1)
         @test count(inquire_variable(file.io, "g1/g2/v7")) == (1, 1, 1, 1, 1)
+        @test count(inquire_variable(file.io, "long_string")) == ()
 
         v1 = adios_get(file, "v1")
         @test !isready(v1)
@@ -148,6 +155,12 @@ if comm_rank == 0
         @test fetch(v5) == makearray(3, float(ℯ))
         @test fetch(v6) == makearray(4, float(ℯ))
         @test fetch(v7) == makearray(5, float(ℯ))
+
+        long_string = adios_get(file, "long_string")
+        @test !isready(long_string)
+        @test fetch(long_string) == fill("a"^5000)
+        @test isready(long_string)
+
         close(file)
     end
 end

--- a/test/highlevel.jl
+++ b/test/highlevel.jl
@@ -156,7 +156,7 @@ if comm_rank == 0
         @test fetch(v6) == makearray(4, float(ℯ))
         @test fetch(v7) == makearray(5, float(ℯ))
 
-        if adios_has_string_length_funcs
+        if have_adios2_get_string
             long_string = adios_get(file, "long_string")
             @test !isready(long_string)
             @test fetch(long_string) == fill("a"^5000)

--- a/test/highlevel.jl
+++ b/test/highlevel.jl
@@ -156,10 +156,16 @@ if comm_rank == 0
         @test fetch(v6) == makearray(4, float(ℯ))
         @test fetch(v7) == makearray(5, float(ℯ))
 
-        long_string = adios_get(file, "long_string")
-        @test !isready(long_string)
-        @test fetch(long_string) == fill("a"^5000)
-        @test isready(long_string)
+        if adios_has_string_length_funcs
+            long_string = adios_get(file, "long_string")
+            @test !isready(long_string)
+            @test fetch(long_string) == fill("a"^5000)
+            @test isready(long_string)
+        else
+            # Without functions that can get the string length from ADIOS2, getting
+            # "long_string" would segfault because it is longer than a hard-coded limit.
+            @test_skip long_string = adios_get(file, "long_string")
+        end
 
         close(file)
     end

--- a/test/highlevel.jl
+++ b/test/highlevel.jl
@@ -17,6 +17,7 @@ if comm_rank == 0
         adios_define_attribute(file, "a3", [float(π), 0])
 
         adios_put!(file, "v1", float(ℯ))
+        adios_put!(file, "v_global", float(ℯ); global_value=true)
         adios_put!(file, "v3", makearray(1, float(ℯ)))
         adios_put!(file, "v4", makearray(2, float(ℯ)))
         adios_put!(file, "v5", makearray(3, float(ℯ)))
@@ -24,6 +25,7 @@ if comm_rank == 0
         adios_put!(file, "g1/g2/v7", makearray(5, float(ℯ)))
 
         @test shapeid(inquire_variable(file.io, "v1")) == shapeid_local_value
+        @test shapeid(inquire_variable(file.io, "v_global")) == shapeid_global_value
         @test shapeid(inquire_variable(file.io, "v3")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "v4")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "v5")) == shapeid_local_array
@@ -76,13 +78,14 @@ if comm_rank == 0
         @test adios_attribute_data(file, "g1/v6", "a6") == [float(π), 0]
 
         @test Set(adios_all_variable_names(file)) ==
-              Set(["v1", "v3", "v4", "v5", "g1/v6", "g1/g2/v7"])
+              Set(["v1", "v_global", "v3", "v4", "v5", "g1/v6", "g1/g2/v7"])
         @test Set(adios_group_variable_names(file, "g1")) == Set(["g1/v6"])
         @test Set(adios_group_variable_names(file, "g1/g2")) ==
               Set(["g1/g2/v7"])
 
         # Local values are converted to global arrays
         @test shapeid(inquire_variable(file.io, "v1")) == shapeid_global_array
+        @test shapeid(inquire_variable(file.io, "v_global")) == shapeid_global_value
         @test shapeid(inquire_variable(file.io, "v3")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "v4")) == shapeid_local_array
         @test shapeid(inquire_variable(file.io, "v5")) == shapeid_local_array
@@ -91,6 +94,7 @@ if comm_rank == 0
               shapeid_local_array
 
         @test ndims(inquire_variable(file.io, "v1")) == 1
+        @test ndims(inquire_variable(file.io, "v_global")) == 0
         @test ndims(inquire_variable(file.io, "v3")) == 1
         @test ndims(inquire_variable(file.io, "v4")) == 2
         @test ndims(inquire_variable(file.io, "v5")) == 3
@@ -98,6 +102,7 @@ if comm_rank == 0
         @test ndims(inquire_variable(file.io, "g1/g2/v7")) == 5
 
         @test shape(inquire_variable(file.io, "v1")) == (1,)
+        @test shape(inquire_variable(file.io, "v_global")) == ()
         @test shape(inquire_variable(file.io, "v3")) ≡ nothing
         @test shape(inquire_variable(file.io, "v4")) ≡ nothing
         @test shape(inquire_variable(file.io, "v5")) ≡ nothing
@@ -105,6 +110,7 @@ if comm_rank == 0
         @test shape(inquire_variable(file.io, "g1/g2/v7")) ≡ nothing
 
         @test start(inquire_variable(file.io, "v1")) == (0,)
+        @test start(inquire_variable(file.io, "v_global")) == ()
         @test start(inquire_variable(file.io, "v3")) ≡ nothing
         @test start(inquire_variable(file.io, "v4")) ≡ nothing
         @test start(inquire_variable(file.io, "v5")) ≡ nothing
@@ -112,6 +118,7 @@ if comm_rank == 0
         @test start(inquire_variable(file.io, "g1/g2/v7")) ≡ nothing
 
         @test count(inquire_variable(file.io, "v1")) == (1,)
+        @test count(inquire_variable(file.io, "v_global")) == ()
         @test count(inquire_variable(file.io, "v3")) == (1,)
         @test count(inquire_variable(file.io, "v4")) == (1, 1)
         @test count(inquire_variable(file.io, "v5")) == (1, 1, 1)
@@ -122,6 +129,10 @@ if comm_rank == 0
         @test !isready(v1)
         @test fetch(v1) == fill(float(ℯ), 1)
         @test isready(v1)
+        v_global = adios_get(file, "v_global")
+        @test !isready(v_global)
+        @test fetch(v_global) == fill(float(ℯ))
+        @test isready(v_global)
         v3 = adios_get(file, "v3")
         v4 = adios_get(file, "v4")
         @test !isready(v3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,8 @@ const ADIOS2_VERSION = let
         @assert false
     end
 end
-adios_has_string_length_funcs = (dlsym(ADIOS2.libadios2_c_handle, :adios2_get_string; throw_error=false) !== nothing)
+
+using ADIOS2: have_adios2_get_string
 
 ################################################################################
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ADIOS2
 using Base.Filesystem
+using Libdl
 using MPI
 using Printf
 using Test
@@ -25,6 +26,7 @@ const ADIOS2_VERSION = let
         @assert false
     end
 end
+adios_has_string_length_funcs = (dlsym(ADIOS2.libadios2_c_handle, :adios2_get_string; throw_error=false) !== nothing)
 
 ################################################################################
 


### PR DESCRIPTION
If using a new enough (or patched) version of the ADIOS library, `adios2_get_string()`/`adios2_attribute_string_data()`/ `adios2_attribute_string_data_array()` can be called to get the length of a string variable/attribute and avoid the need for a hard-coded maximum length used to set the string buffer size.

Requires this patch to be applied to the ADIOS2 library v2.10.2 to back-port the fixes from https://github.com/ornladios/ADIOS2/pull/4801 and https://github.com/ornladios/ADIOS2/pull/4804 (these fixes will be included in v2.10.3 when that is released):
[ADIOS2-PR4801-PR4804.patch](https://github.com/user-attachments/files/24653341/ADIOS2-PR4801-PR4804.patch)

Fixes #23.